### PR TITLE
Adds plugin profile.js to allow preparing JBrowse release

### DIFF
--- a/js/HierarchicalCheckboxPlugin.profile.js
+++ b/js/HierarchicalCheckboxPlugin.profile.js
@@ -1,0 +1,62 @@
+function copyOnly(mid) {
+    return mid in {
+        // There are no modules right now that are copy-only. If you have some, though, just add
+        // them here like this:
+        // 'app/module': 1
+    };
+}
+
+var profile = {
+    action: 'release',
+    cssOptimize: 'comments',
+    mini: true,
+
+    basePath: '../../../src',
+    packages: [
+        {name: 'HierarchicalCheckboxPlugin', location: '../plugins/HierarchicalCheckboxPlugin/js' }
+    ],
+
+    layerOptimize: 'closure',
+    stripConsole: 'normal',
+    selectorEngine: 'acme',
+
+    layers: {
+        'HierarchicalCheckboxPlugin/main': {
+            include: [
+                'HierarchicalCheckboxPlugin'
+            ],
+            exclude: [ 'JBrowse' ]
+        }
+    },
+
+    staticHasFeatures: {
+        'dojo-trace-api':0,
+        'dojo-log-api':0,
+        'dojo-publish-privates':0,
+        'dojo-sync-loader':0,
+        'dojo-xhr-factory':0,
+        'dojo-test-sniff':0
+    },
+
+    resourceTags: {
+        // Files that contain test code.
+        test: function (filename, mid) {
+            return false;
+        },
+
+        // Files that should be copied as-is without being modified by the build system.
+        copyOnly: function (filename, mid) {
+            return copyOnly(mid);
+        },
+
+        // Files that are AMD modules.
+        amd: function (filename, mid) {
+            return !copyOnly(mid) && /\.js$/.test(filename);
+        },
+
+        // Files that should not be copied when the “mini” compiler flag is set to true.
+        miniExclude: function (filename, mid) {
+            return ! ( /^HierarchicalCheckboxPlugin/.test(mid) );
+        }
+    }
+};

--- a/js/main.js
+++ b/js/main.js
@@ -83,10 +83,10 @@ return declare( JBrowsePlugin,
                     var isCollapsed = lang.getObject( 'collapsed.'+categoryPath, false, thisB.state );
                     var checkBoxId = categoryGoodName+'_checkBox';
                     
-                    var labelDom = domConstruct.create('label', {title:'select/deselect all tracks from this category', className:'category-select'});
+                    var labelDom = domConstruct.create('label', {'title':'select/deselect all tracks from this category', 'className':'category-select'});
                     domConstruct.create( 'span',{innerHTML:'select all from category'},labelDom );
                     
-                    var checkDom = domConstruct.create( 'input',{type:'checkbox', class:'hierachcheck', id:checkBoxId, value:categoryPath}, labelDom );
+                    var checkDom = domConstruct.create( 'input',{'type':'checkbox', 'class':'hierachcheck', 'id':checkBoxId, 'value':categoryPath}, labelDom );
                     
                     var c = new TitlePane(
                         { title: '<span class="categoryName">'+categoryName+'</span>' +' <span class="trackCount">0</span>',


### PR DESCRIPTION
Hi @bhofmei , 
Thank you for developing this (and other useful) JBrowse plugins! This PR corrects a minor syntax error in the main.js as well as adds a profile.js for this plugin, so that when a `make build/Makefile release` is run in the JBrowse directory, the plugin code is successfully parsed and minified.

Please review this PR and accept at your convenience.

Thank you!
